### PR TITLE
Add README and environment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SSH_HOST=cardinal.osc.edu
+SSH_USER=youruser
+SSH_PASS=yourpassword
+SQUEUE_COMMAND=squeue -A pys0302

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.DS_Store
+.env
+dist/
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# OSC Job Monitoring App
+
+This project provides a small containerized setup with a Flask backend and a Streamlit frontend served through NGINX. The backend connects to a remote cluster via SSH to fetch job queue data, while the frontend displays that information in a dashboard.
+
+## Running locally
+
+The easiest way to run the application is using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+The frontend will be available at `https://localhost` (NGINX terminates TLS), and the backend is exposed on port `5000` within the compose network.
+
+### Environment variables
+
+The backend requires SSH credentials to connect to the cluster. These values can be provided using environment variables:
+
+- `SSH_HOST` – remote host name
+- `SSH_USER` – SSH user
+- `SSH_PASS` – SSH password
+- `SQUEUE_COMMAND` – command used to fetch job information (default: `squeue -A pys0302`)
+
+You can set them in a `.env` file or directly in the environment before running Docker Compose. An example configuration is provided in `.env.example`.
+
+## Development
+
+Typical Python build artefacts and virtual environments are ignored through `.gitignore`.
+

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1,14 +1,15 @@
 from flask import Flask, jsonify
+import os
 import paramiko
 import threading
 import time
 
 app = Flask(__name__)
 
-SSH_HOST = 'cardinal.osc.edu'
-SSH_USER = 'vikrambathala4'
-SSH_PASS = 'Homeboxoffice@3'
-SQUEUE_COMMAND = 'squeue -A pys0302'
+SSH_HOST = os.getenv("SSH_HOST", "cardinal.osc.edu")
+SSH_USER = os.getenv("SSH_USER", "")
+SSH_PASS = os.getenv("SSH_PASS", "")
+SQUEUE_COMMAND = os.getenv("SQUEUE_COMMAND", "squeue -A pys0302")
 
 job_data = []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile
     container_name: job-backend
     restart: always
+    env_file:
+      - .env
     expose:
       - "5000"
     networks:


### PR DESCRIPTION
## Summary
- read SSH settings from environment variables
- document how to run the app via Docker Compose
- add `.env.example` and `.gitignore`
- load environment from `.env` in docker-compose

## Testing
- `python3 -m py_compile backend/backend.py frontend/frontend.py`
- ⚠️ `docker-compose` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886e8d5b61083228e463e9c992687e0