### PR TITLE
Fix Dockerfile CMD formatting

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,4 @@ RUN pip install streamlit pandas requests streamlit-autorefresh
 EXPOSE 8501
 
 ENTRYPOINT ["streamlit", "run", "frontend.py"]
-CMD ["--server.port=8501", 
-     "--server.address=0.0.0.0", 
-     "--server.enableCORS=false", 
-     "--server.enableXsrfProtection=false"]
+CMD ["--server.port=8501", "--server.address=0.0.0.0", "--server.enableCORS=false", "--server.enableXsrfProtection=false"]


### PR DESCRIPTION
## Summary
- fix Dockerfile CMD so Docker parser doesn't misread newlines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ea23495883229c8bbac5d3d2f8ff