### PR TITLE
Fix job-frontend build config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
 
   job-frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: frontend/Dockerfile
     container_name: job-frontend
     restart: always
     expose:


### PR DESCRIPTION
## Summary
- set frontend Dockerfile path in docker-compose

## Testing
- `docker-compose up --build -d` *(fails: Error while fetching server API version: connection aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6886f3effbd48322b96146f624565a7b