### PR TITLE
Add login flow to OSC job monitor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 SSH_HOST=cardinal.osc.edu
-SSH_USER=youruser
-SSH_PASS=yourpassword
 SQUEUE_COMMAND=squeue -A pys0302
+DB_PATH=users.db

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ The frontend will be available at `https://localhost` (NGINX terminates TLS), an
 
 ### Environment variables
 
-The backend requires SSH credentials to connect to the cluster. These values can be provided using environment variables:
+The backend requires SSH credentials to connect to the cluster. These values can
+be provided using environment variables:
 
 - `SSH_HOST` – remote host name
-- `SSH_USER` – SSH user
-- `SSH_PASS` – SSH password
-- `SQUEUE_COMMAND` – command used to fetch job information (default: `squeue -A PYS0302`)
-- `SHOW_JOB_COMMAND` – base command to fetch detailed job data (default: `scontrol show job`)
+- `SQUEUE_COMMAND` – command used to fetch job information (default:
+  `squeue -A PYS0302`)
+- `SHOW_JOB_COMMAND` – base command to fetch detailed job data (default:
+  `scontrol show job`)
+- `DB_PATH` – location of the SQLite database used for storing registered users
 
 You can set them in a `.env` file or directly in the environment before running Docker Compose. An example configuration is provided in `.env.example`.
 
@@ -28,6 +30,8 @@ You can set them in a `.env` file or directly in the environment before running 
 
 The backend exposes the following routes:
 
+- `/register` – create a new user record with HPC credentials.
+- `/login` – obtain an authentication token.
 - `/jobs` – returns a list of jobs for the configured account.
 - `/job/<JOBID>` – returns detailed information for a specific job using `scontrol show job`.
 

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1,69 +1,139 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 import os
 import paramiko
-import threading
-import time
+import sqlite3
+import uuid
+from werkzeug.security import generate_password_hash, check_password_hash
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app)
 
 SSH_HOST = os.getenv("SSH_HOST", "cardinal.osc.edu")
-SSH_USER = os.getenv("SSH_USER", "")
-SSH_PASS = os.getenv("SSH_PASS", "")
 SQUEUE_COMMAND = os.getenv("SQUEUE_COMMAND", "squeue -A PYS0302")
 SHOW_JOB_COMMAND = os.getenv("SHOW_JOB_COMMAND", "scontrol show job")
+DB_PATH = os.getenv("DB_PATH", "users.db")
 
-job_data = []
+sessions = {}
 
-def fetch_job_data():
-    global job_data
-    while True:
-        try:
-            ssh = paramiko.SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            ssh.connect(SSH_HOST, username=SSH_USER, password=SSH_PASS)
-            stdin, stdout, stderr = ssh.exec_command(SQUEUE_COMMAND)
-            output = stdout.read().decode()
-            ssh.close()
 
-            lines = output.strip().split('\n')
-            headers = lines[0].split()
-            jobs = [dict(zip(headers, line.split(None, len(headers) - 1))) for line in lines[1:]]
-            job_data = jobs
-        except Exception as e:
-            job_data = [{"error": str(e)}]
-        time.sleep(10)
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        ssh_user TEXT NOT NULL,
+        ssh_pass TEXT NOT NULL
+    )"""
+    )
+    conn.commit()
+    conn.close()
 
-threading.Thread(target=fetch_job_data, daemon=True).start()
 
-@app.route("/")
-def hello():
-    return "Hello from Python Flask Microservice!"
+def run_command(user, pwd, command):
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(SSH_HOST, username=user, password=pwd)
+    stdin, stdout, stderr = ssh.exec_command(command)
+    output = stdout.read().decode()
+    ssh.close()
+    return output
+
+
+@app.route("/register", methods=["POST"])
+def register():
+    data = request.get_json(force=True)
+    username = data.get("username")
+    password = data.get("password")
+    ssh_user = data.get("ssh_user")
+    ssh_pass = data.get("ssh_pass")
+    if not (username and password and ssh_user and ssh_pass):
+        return jsonify({"error": "Missing fields"}), 400
+
+    pw_hash = generate_password_hash(password)
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        c = conn.cursor()
+        c.execute(
+            "INSERT INTO users (username, password_hash, ssh_user, ssh_pass) VALUES (?, ?, ?, ?)",
+            (username, pw_hash, ssh_user, ssh_pass),
+        )
+        conn.commit()
+        conn.close()
+        return jsonify({"status": "registered"})
+    except sqlite3.IntegrityError:
+        return jsonify({"error": "User exists"}), 400
+
+
+@app.route("/login", methods=["POST"])
+def login():
+    data = request.get_json(force=True)
+    username = data.get("username")
+    password = data.get("password")
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "SELECT password_hash, ssh_user, ssh_pass FROM users WHERE username=?",
+        (username,),
+    )
+    row = c.fetchone()
+    conn.close()
+    if not row or not check_password_hash(row[0], password):
+        return jsonify({"error": "Invalid credentials"}), 401
+    token = str(uuid.uuid4())
+    sessions[token] = {"ssh_user": row[1], "ssh_pass": row[2]}
+    return jsonify({"token": token})
+
+
+def get_session(request):
+    token = request.headers.get("Authorization")
+    if not token:
+        return None
+    return sessions.get(token)
+
 
 @app.route("/jobs")
 def get_jobs():
-    return jsonify(job_data)
+    sess = get_session(request)
+    if not sess:
+        return jsonify({"error": "Unauthorized"}), 401
+    try:
+        output = run_command(sess["ssh_user"], sess["ssh_pass"], SQUEUE_COMMAND)
+        lines = output.strip().split("\n")
+        headers = lines[0].split()
+        jobs = [dict(zip(headers, line.split(None, len(headers) - 1))) for line in lines[1:]]
+        return jsonify(jobs)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 @app.route("/job/<jobid>")
 def get_job_detail(jobid):
-    """Fetch detailed information for a single job."""
+    sess = get_session(request)
+    if not sess:
+        return jsonify({"error": "Unauthorized"}), 401
     try:
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(SSH_HOST, username=SSH_USER, password=SSH_PASS)
-        command = f"{SHOW_JOB_COMMAND} {jobid}"
-        stdin, stdout, stderr = ssh.exec_command(command)
-        output = stdout.read().decode()
-        ssh.close()
-
+        output = run_command(
+            sess["ssh_user"], sess["ssh_pass"], f"{SHOW_JOB_COMMAND} {jobid}"
+        )
         detail = {}
-        for token in output.replace("\n", " ").split():
-            if "=" in token:
-                key, value = token.split("=", 1)
+        for token_ in output.replace("\n", " ").split():
+            if "=" in token_:
+                key, value = token_.split("=", 1)
                 detail[key] = value
         return jsonify(detail)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+
+@app.route("/")
+def index():
+    return "OSC Job Backend"
+
+
 if __name__ == "__main__":
+    init_db()
     app.run(host="0.0.0.0", port=5000)

--- a/frontend-react/src/App.jsx
+++ b/frontend-react/src/App.jsx
@@ -1,48 +1,37 @@
-import { useEffect, useState } from 'react'
-import Container from '@mui/material/Container'
-import CssBaseline from '@mui/material/CssBaseline'
-import Typography from '@mui/material/Typography'
-import { DataGrid } from '@mui/x-data-grid'
+import { useState } from 'react'
+import Login from './components/Login'
+import Register from './components/Register'
+import JobTable from './components/JobTable'
 
 function App() {
-  const [rows, setRows] = useState([])
+  const [token, setToken] = useState(localStorage.getItem('token'))
+  const [page, setPage] = useState(token ? 'jobs' : 'login')
 
-  useEffect(() => {
-    const fetchJobs = () => {
-      fetch('/jobs')
-        .then(res => res.json())
-        .then(data => {
-          if (Array.isArray(data)) {
-            setRows(data.map((row, idx) => ({ id: idx, ...row })))
-          }
-        })
-        .catch(err => console.error(err))
-    }
-    fetchJobs()
-    const id = setInterval(fetchJobs, 10000)
-    return () => clearInterval(id)
-  }, [])
+  const handleLogin = tok => {
+    setToken(tok)
+    localStorage.setItem('token', tok)
+    setPage('jobs')
+  }
 
-  const columns = [
-    { field: 'JOBID', headerName: 'Job ID', flex: 1 },
-    { field: 'NAME', headerName: 'Name', flex: 1 },
-    { field: 'USER', headerName: 'User', flex: 1 },
-    { field: 'ST', headerName: 'Status', flex: 1 },
-    { field: 'TIME', headerName: 'Time', flex: 1 },
-    { field: 'NODES', headerName: 'Nodes', flex: 1 },
-    { field: 'NODELIST(REASON)', headerName: 'Node List', flex: 1 },
-  ]
+  const logout = () => {
+    setToken(null)
+    localStorage.removeItem('token')
+    setPage('login')
+  }
+
+  if (page === 'login') {
+    return <Login onLogin={handleLogin} switchToRegister={() => setPage('register')} />
+  }
+
+  if (page === 'register') {
+    return <Register onRegister={() => setPage('login')} switchToLogin={() => setPage('login')} />
+  }
 
   return (
-    <Container maxWidth="xl">
-      <CssBaseline />
-      <Typography variant="h4" gutterBottom>
-        Job Monitor
-      </Typography>
-      <div style={{ height: 600, width: '100%' }}>
-        <DataGrid rows={rows} columns={columns} pageSize={25} />
-      </div>
-    </Container>
+    <div>
+      <button onClick={logout}>Logout</button>
+      <JobTable token={token} />
+    </div>
   )
 }
 

--- a/frontend-react/src/components/JobTable.jsx
+++ b/frontend-react/src/components/JobTable.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import Container from '@mui/material/Container'
+import CssBaseline from '@mui/material/CssBaseline'
+import Typography from '@mui/material/Typography'
+import { DataGrid } from '@mui/x-data-grid'
+
+function JobTable({ token }) {
+  const [rows, setRows] = useState([])
+
+  useEffect(() => {
+    const fetchJobs = () => {
+      fetch('/jobs', { headers: { Authorization: token } })
+        .then(res => res.json())
+        .then(data => {
+          if (Array.isArray(data)) {
+            setRows(data.map((row, idx) => ({ id: idx, ...row })))
+          }
+        })
+        .catch(err => console.error(err))
+    }
+    fetchJobs()
+    const id = setInterval(fetchJobs, 10000)
+    return () => clearInterval(id)
+  }, [token])
+
+  const columns = [
+    { field: 'JOBID', headerName: 'Job ID', flex: 1 },
+    { field: 'NAME', headerName: 'Name', flex: 1 },
+    { field: 'USER', headerName: 'User', flex: 1 },
+    { field: 'ST', headerName: 'Status', flex: 1 },
+    { field: 'TIME', headerName: 'Time', flex: 1 },
+    { field: 'NODES', headerName: 'Nodes', flex: 1 },
+    { field: 'NODELIST(REASON)', headerName: 'Node List', flex: 1 }
+  ]
+
+  return (
+    <Container maxWidth="xl">
+      <CssBaseline />
+      <Typography variant="h4" gutterBottom>
+        Job Monitor
+      </Typography>
+      <div style={{ height: 600, width: '100%' }}>
+        <DataGrid rows={rows} columns={columns} pageSize={25} />
+      </div>
+    </Container>
+  )
+}
+
+export default JobTable

--- a/frontend-react/src/components/Login.jsx
+++ b/frontend-react/src/components/Login.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+import Box from '@mui/material/Box'
+
+function Login({ onLogin, switchToRegister }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.token) {
+          onLogin(data.token)
+        } else {
+          alert(data.error || 'Login failed')
+        }
+      })
+      .catch(err => console.error(err))
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <TextField label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
+      <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <Button type="submit" variant="contained">Login</Button>
+      <Button onClick={switchToRegister}>Register</Button>
+    </Box>
+  )
+}
+
+export default Login

--- a/frontend-react/src/components/Register.jsx
+++ b/frontend-react/src/components/Register.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
+import Box from '@mui/material/Box'
+
+function Register({ onRegister, switchToLogin }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [sshUser, setSshUser] = useState('')
+  const [sshPass, setSshPass] = useState('')
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    fetch('/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password, ssh_user: sshUser, ssh_pass: sshPass })
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.status === 'registered') {
+          onRegister()
+        } else {
+          alert(data.error || 'Registration failed')
+        }
+      })
+      .catch(err => console.error(err))
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <TextField label="Username" value={username} onChange={e => setUsername(e.target.value)} required />
+      <TextField label="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <TextField label="SSH User" value={sshUser} onChange={e => setSshUser(e.target.value)} required />
+      <TextField label="SSH Password" type="password" value={sshPass} onChange={e => setSshPass(e.target.value)} required />
+      <Button type="submit" variant="contained">Register</Button>
+      <Button onClick={switchToLogin}>Back to Login</Button>
+    </Box>
+  )
+}
+
+export default Register


### PR DESCRIPTION
## Summary
- support user registration and login with a small SQLite database
- fetch job data on demand using credentials from login sessions
- add React components for Login, Register, and Job display
- document new API endpoints and configuration options

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `python -m py_compile backend.py`


------
https://chatgpt.com/codex/tasks/task_e_6886fb4aefec832294b9f58bf2dffa1f