### PR TITLE
Set correct base path for React build

### DIFF
--- a/frontend-react/vite.config.js
+++ b/frontend-react/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/monitor/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- update vite config to serve the frontend under `/monitor/`

## Testing
- `npm install`
- `npm run build`
- `curl -k http://localhost:8502/monitor/`

------
https://chatgpt.com/codex/tasks/task_e_6886fe5549588322bb79e85e95383a6f